### PR TITLE
Dependencies not being installed

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -5,7 +5,7 @@ PERSPECTIVE_API_TOKEN=
 
 # for use with provided docker containers
 MONGO_SERVER=toximongo:27017
-MONGO_DATABASE=toxichatbot
+MONGO_DATABASE=toxichatdb
 MONGO_USER=root
 MONGO_PASSWORD=toxipass
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -12,8 +12,7 @@ services:
         - ./:/home/node/app
     expose:
         - "8080"
-    command: "yarn"
-    command: "yarn start"
+    command: [sh, -c, "yarn && yarn start"]
 
   mongo:
     container_name: toximongo


### PR DESCRIPTION
Resolves issue #14 

Dependencies were not being installed by container as `command:` was only running the last occurrence. To get around this, I instead start a shell inside the container and run `yarn && yarn start`. This guarantees the dependencies will be installed on the first start up and will start the application once dependencies finish installing.