### PR TITLE
Check for null objects during /list command

### DIFF
--- a/src/middleware/handlers/list.ts
+++ b/src/middleware/handlers/list.ts
@@ -22,7 +22,7 @@ export const listHandler = async (
 
   const chats = await findChatsForUser(ctx.from);
 
-  if (chats.length < 1) {
+  if (chats == null || chats.length < 1) {
     return ctx.reply(
       'You have no groups set up yet. Try calling /start in your group.',
     );

--- a/src/modules/db/index.ts
+++ b/src/modules/db/index.ts
@@ -80,7 +80,9 @@ export const findChatsForUser = async (
 ): Promise<IChat[]> => {
   try {
     const user = await findUser(telegramUser);
-    return await Chat.find({ users: user._id });
+    if(user) {
+      return await Chat.find({ users: user._id });
+    }
   } catch (err) {
     logError(err);
   }


### PR DESCRIPTION
Occasionally, a null object is returned from the /list command. This happens when setting up a new development environment and using the same Telegram bot account that was previously added to groups in a different environment. This PR checks for returned null values.

- Check if user was found before looking up any chats for that user.
- If returned chats object is null OR has fewer than 1 chat, inform user they have not chats. 

Resolves #16