### PR TITLE
Hotfix - Fix typescript linting bug

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -46,6 +46,10 @@
           "_id"
         ]
       }
+    ],
+    "no-shadow": "off",
+    "@typescript-eslint/no-shadow": [
+      "error"
     ]
   }
 }


### PR DESCRIPTION
A bug in eslint for typescript reports a false positive on enums and other structures. They recommend applying these rule changes.

This answer is what I used: https://stackoverflow.com/a/65768375/370539